### PR TITLE
DATAGO-54957: Changes for info log level from error to info, and update to exclude some paths from reserved objects.

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/RestCommandList.java
+++ b/src/main/java/com/solace/tools/solconfig/RestCommandList.java
@@ -54,10 +54,10 @@ public class RestCommandList {
     private void execute(SempClient sempClient, List<Command> commandList) {
         List<Command> retryCommands = new LinkedList<>();
         for (Command cmd : commandList) {
-            Utils.err("%s %s ", cmd.method.name(), cmd.resourcePath);
+            Utils.log(String.format("%s %s ", cmd.method.name(), cmd.resourcePath));
             var meta = sempClient.sendAndGetMeta(cmd.method.name(), cmd.resourcePath, cmd.payload);
             if (meta.getResponseCode() == 200) {
-                Utils.err("OK%n");
+                Utils.log("OK%n");
             } else {
                 int semp_code = meta.getError().getCode();
                 if (cmd.method == HTTPMethod.DELETE &&

--- a/src/main/java/com/solace/tools/solconfig/RestCommandList.java
+++ b/src/main/java/com/solace/tools/solconfig/RestCommandList.java
@@ -57,7 +57,7 @@ public class RestCommandList {
             Utils.log(String.format("%s %s ", cmd.method.name(), cmd.resourcePath));
             var meta = sempClient.sendAndGetMeta(cmd.method.name(), cmd.resourcePath, cmd.payload);
             if (meta.getResponseCode() == 200) {
-                Utils.log("OK%n");
+                Utils.log("OK");
             } else {
                 int semp_code = meta.getError().getCode();
                 if (cmd.method == HTTPMethod.DELETE &&

--- a/src/main/java/com/solace/tools/solconfig/model/ConfigObject.java
+++ b/src/main/java/com/solace/tools/solconfig/model/ConfigObject.java
@@ -4,7 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.solace.tools.solconfig.RestCommandList;
 import com.solace.tools.solconfig.Utils;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -146,8 +156,6 @@ public class ConfigObject {
      * [Reserved Characters](https://docs.solace.com/Admin/SEMP/SEMP-API-Protocol.htm)
      * > It is recommended that you encode all characters outside of the unreserved character set for event broker
      * > configuration object identifying attributes.
-     * @param input
-     * @return
      */
     static String percentEncoding(String input) {
         var bytes = input.getBytes(StandardCharsets.UTF_8);
@@ -442,12 +450,5 @@ public class ConfigObject {
     public void sortChildren() {
         getChildren().values().forEach(l -> l.sort(Comparator.comparing(ConfigObject::getObjectId)));
         forEachChild(ConfigObject::sortChildren);
-    }
-
-    public void ignoreObjectsForCloudInstance() {
-        if (SempSpec.SPEC_PATHS_OF_OBJECTS_OF_CLOUD_INSTANCE.contains(specPath)){
-            attributes.put(SempSpec.SKIP_THIS_OBJECT, true);
-        }
-        forEachChild(ConfigObject::ignoreObjectsForCloudInstance);
     }
 }

--- a/src/main/java/com/solace/tools/solconfig/model/ConfigObject.java
+++ b/src/main/java/com/solace/tools/solconfig/model/ConfigObject.java
@@ -200,7 +200,6 @@ public class ConfigObject {
      * @return if this object is a reserved object.
      */
     public boolean isReservedObject() {
-
         List<String> excludeFromReservedObjectList = new ArrayList<>();
         List<String> excludeFromReservedObjectIdsList = new ArrayList<>();
 
@@ -214,17 +213,21 @@ public class ConfigObject {
             excludeFromReservedObjectIdsList = Arrays.asList(excludeFromReservedObjectIds.split(","));
         }
 
+        return isReservedObject(getObjectId(), this.specPath, excludeFromReservedObjectList, excludeFromReservedObjectIdsList);
+    }
+
+    public boolean isReservedObject(String objectId, String specPath,
+                                    List<String> excludeFromReservedObjectList,
+                                    List<String> excludeFromReservedObjectIdsList) {
+
         boolean isReserved = false;
-        String objectId = getObjectId();
-        String specPathString = this.specPath;
-        String specObjectPath = specPathString + PATH_DELIMITER + objectId;
+        String specObjectPath = specPath + PATH_DELIMITER + objectId;
 
         if(!reservedObjectsStartsWith.isBlank()) {
             isReserved = objectId.startsWith(reservedObjectsStartsWith);
         }
         if(!excludeFromReservedObjectList.isEmpty()) {
-
-            isReserved = isReserved && excludeFromReservedObjectList.stream().noneMatch(specPathString::equals);
+            isReserved = isReserved && excludeFromReservedObjectList.stream().noneMatch(specPath::equals);
         }
         if(!excludeFromReservedObjectIdsList.isEmpty()) {
             isReserved = isReserved && excludeFromReservedObjectIdsList.stream().noneMatch(specObjectPath::equals);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 solace.tools.solconfig.exitOnErrors = false
+# Objects that starts with # are reserved.
+solace.tools.solconfig.objects.reserved.startsWith = %23
+
+# Exceptions to the reserved objects list
+solace.tools.solconfig.objects.reserved.excludeList = /msgVpns/queues,/msgVpns/queues/subscriptions,\
+  /msgVpns/topicEndpoints,/msgVpns/topicEndpoints/subscriptions
+
+# Exceptions to the reserved objects id list
+solace.tools.solconfig.objects.reserved.excludeObjectIdList =

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ solace.tools.solconfig.objects.reserved.startsWith = %23
 
 # Exceptions to the reserved objects list
 solace.tools.solconfig.objects.reserved.excludeList = /msgVpns/queues,/msgVpns/queues/subscriptions,\
-  /msgVpns/topicEndpoints,/msgVpns/topicEndpoints/subscriptions
+  /msgVpns/topicEndpoints
 
 # Exceptions to the reserved objects id list
 solace.tools.solconfig.objects.reserved.excludeObjectIdList =

--- a/src/test/java/com/solace/tools/solconfig/model/ConfigObjectTest.java
+++ b/src/test/java/com/solace/tools/solconfig/model/ConfigObjectTest.java
@@ -1,0 +1,69 @@
+package com.solace.tools.solconfig.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConfigObjectTest {
+    private static List<String> reservedExcludeObjectsList;
+    private static List<String> reservedExcludeObjectIdsList;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        reservedExcludeObjectsList = List.of("/msgVpns/queues", "/msgVpns/queues/subscriptions",
+                "/msgVpns/topicEndpoints");
+
+        reservedExcludeObjectIdsList = List.of("/msgVpns/aclProfiles/%23acl-profile");
+    }
+
+    @Test
+    void testisReservedObject() {
+        ConfigObject configObject = new ConfigObject();
+        boolean isReserved = configObject.isReservedObject("%23test", "/msgVpns/queues", reservedExcludeObjectsList, reservedExcludeObjectIdsList);
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23subs", "/msgVpns/queues/subscriptions", reservedExcludeObjectsList, reservedExcludeObjectIdsList);
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23te1", "/msgVpns/topicEndpoints", reservedExcludeObjectsList, reservedExcludeObjectIdsList);
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23test", "/msgVpns/clientProfiles", reservedExcludeObjectsList, reservedExcludeObjectIdsList);
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23acl-profile", "/msgVpns/aclProfiles", reservedExcludeObjectsList, reservedExcludeObjectIdsList);
+        assertEquals(false, isReserved);
+    }
+
+    @Test
+    void testisReservedObjectNoExcludeObjects() {
+        ConfigObject configObject = new ConfigObject();
+        boolean isReserved = configObject.isReservedObject("%23test", "/msgVpns/queues", new ArrayList<>(), reservedExcludeObjectIdsList);
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23subs", "/msgVpns/queues/subscriptions", new ArrayList<>(), reservedExcludeObjectIdsList);
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23te1", "/msgVpns/topicEndpoints", new ArrayList<>(), reservedExcludeObjectIdsList);
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23test", "/msgVpns/clientProfiles", new ArrayList<>(), reservedExcludeObjectIdsList);
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23acl-profile", "/msgVpns/aclProfiles", new ArrayList<>(), reservedExcludeObjectIdsList);
+        assertEquals(false, isReserved);
+    }
+
+    @Test
+    void testisReservedObjectNoExcludeObjectIds() {
+        ConfigObject configObject = new ConfigObject();
+        boolean isReserved = configObject.isReservedObject("%23test", "/msgVpns/queues", reservedExcludeObjectsList, new ArrayList<>());
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23subs", "/msgVpns/queues/subscriptions", reservedExcludeObjectsList, new ArrayList<>());
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23te1", "/msgVpns/topicEndpoints", reservedExcludeObjectsList, new ArrayList<>());
+        assertEquals(false, isReserved);
+        isReserved = configObject.isReservedObject("%23test", "/msgVpns/clientProfiles", reservedExcludeObjectsList, new ArrayList<>());
+        assertEquals(true, isReserved);
+        isReserved = configObject.isReservedObject("%23acl-profile", "/msgVpns/aclProfiles", reservedExcludeObjectsList, new ArrayList<>());
+        assertEquals(true, isReserved);
+    }
+}
+


### PR DESCRIPTION
* Changes for success path log level from error to info
* Update to exclude some paths from reserved objects to be able to backup and restore queues and topic endpoints that start with #