### PR TITLE
DATAGO-97038: blur passwords before logging

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -10,7 +10,14 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.Authenticator;
@@ -40,16 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
-
-import lombok.Getter;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SempClient {
@@ -224,7 +221,7 @@ public class SempClient {
     }
 
     private String sendWithAbsoluteURI(String method, String absUri, String payload) {
-        log.info("Sending with absolute URI {} {}", method, absUri);
+        log.info("Sending with absolute URI {} {}", method, sanitizeUri(absUri));
         var bp = Objects.isNull(payload) || payload.isEmpty() ?
                 BodyPublishers.noBody() :
                 BodyPublishers.ofString(payload);
@@ -239,18 +236,26 @@ public class SempClient {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (InterruptedException | IOException e) {
             Utils.errPrintlnAndExit(e, "%s %s with playload:%n%s%n%s",
-                    method.toUpperCase(), absUri, payload, e.toString());
+                    method.toUpperCase(), sanitizeUri(absUri), sanitizeJsonBody(payload), e.toString());
         }
         var body = Optional.ofNullable(response)
                 .map(HttpResponse::body);
         if (body.isEmpty() || body.get().isEmpty()) {
             Utils.errPrintlnAndExit((Exception) null,
                     "%s %s returns empty body",
-                    method, absUri);
+                    method, sanitizeUri(absUri));
         }
-        log.info("{} {}\n{}\n{}", method.toUpperCase(), absUri,
-                Objects.isNull(payload) || payload.isEmpty() ? "" : payload, body.get());
+        log.info("{} {}\n{}\n{}", method.toUpperCase(), sanitizeUri(absUri),
+                Objects.isNull(payload) || payload.isEmpty() ? "" : sanitizeJsonBody(payload), sanitizeJsonBody(body.get()));
         return body.orElse(null);
+    }
+
+    private String sanitizeUri(String input) {
+        return Utils.sanitizeUrl(input);
+    }
+
+    private String sanitizeJsonBody(String input) {
+        return Utils.sanitizeBody(input);
     }
 
 

--- a/src/main/java/com/solace/tools/solconfig/Utils.java
+++ b/src/main/java/com/solace/tools/solconfig/Utils.java
@@ -5,10 +5,16 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.solace.tools.solconfig.model.SempSpec;
 import com.solace.tools.solconfig.model.SolConfigException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -16,17 +22,36 @@ public class Utils {
     public static ObjectMapper objectMapper = new ObjectMapper();
     public static Properties properties = PropertiesLoader.loadProperties("application.properties");
 
+    public static String sanitizeUrl(String data) {
+        if (data != null && data.contains(SempSpec.OPAQUE_PASSWORD + "=")) {
+            return data.replaceAll("(opaquePassword=)[^&\"]*([&\"]|$)", "$1*****$2");
+        }
+        return data;
+    }
+
+    public static String sanitizeBody(String body) {
+        if (body == null) {
+            return null;
+        }
+
+        if(body.toLowerCase().contains("password")){
+            return "Sensitive data, omitted for logging";
+        }
+
+        return body;
+    }
+
     // TODO: move to SempSpec class
-    public static String getCollectionNameFromUri(String uri){
+    public static String getCollectionNameFromUri(String uri) {
         String[] items = uri.split("/");
-        return items[items.length-1].split("\\?")[0];
+        return items[items.length - 1].split("\\?")[0];
     }
 
     public static Optional<String> getFirstMatch(String input, Pattern re) {
         var m = re.matcher(input);
         if (m.find()) {
             return Optional.of(m.group(1));
-        }else {
+        } else {
             return Optional.empty();
         }
     }

--- a/src/test/java/com/solace/tools/solconfig/UtilsTest.java
+++ b/src/test/java/com/solace/tools/solconfig/UtilsTest.java
@@ -1,0 +1,65 @@
+package com.solace.tools.solconfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilsTest {
+
+   private String body = "{" +
+           "\"data\": {" +
+           "\"somePassword\": \"asdfasdf\"," +
+           "\"password\":  \"42345234\"," +
+           "\"topicEndpointsUri\": \"https://mr-connection-mwdinssvzdp.messaging.solace.cloud:943/SEMP/v2/config/msgVpns/serv1/topicEndpoints\"," +
+           "\"uri\": \"https://mr-connection-mwdinssvzdp.messaging.solace.cloud:943/SEMP/v2/config/msgVpns/serv1\"" +
+           "}," +
+           "\"meta\":{" +
+           "\"request\":{" +
+           "\"method\": \"PUT\"," +
+           "\"uri\": \"https://mr-connection-mwdinssvzdp.messaging.solace.cloud:943/SEMP/v2/config/msgVpns/serv1?opaquePassword=asdfasasd\"" +
+           "}," +
+           "\"responseCode\":200" +
+           "}" +
+           "}";
+
+   private String expectedBody = "Sensitive data, omitted for logging";
+
+
+
+    @Test
+    void blurPasswords() {
+        String uri = "https://localhost:8080/SEMP/v2/config/msgVpns/default/queues/queue1?opaquePassword=1234";
+        String expectedUri = "https://localhost:8080/SEMP/v2/config/msgVpns/default/queues/queue1?opaquePassword=*****";
+
+        String actual = Utils.sanitizeUrl(uri);
+
+        assertEquals(expectedUri, actual);
+    }
+
+    @Test
+    void returnTheSameIfNoPasswords() {
+        String uri = "https://localhost:8080/SEMP/v2/config/msgVpns/default/queues/queue1";
+
+        String actual = Utils.sanitizeUrl(uri);
+
+        assertEquals(uri, actual);
+    }
+
+    @Test
+    void returnNullIfDataIsNull() {
+        String uri = null;
+
+        String actual = Utils.sanitizeUrl(uri);
+
+        assertEquals(uri, actual);
+    }
+
+    @Test
+    void blurPasswordsInJsonFields() {
+        String actual = Utils.sanitizeBody(
+                Utils.sanitizeUrl(body)
+        );
+
+        assertEquals(expectedBody, actual);
+    }
+}


### PR DESCRIPTION
### What is the purpose of this change?
https://sol-jira.atlassian.net/browse/DATAGO-97038

blur passwords before logging

### How is this accomplished?

Find if data contains a password and replace it with "****"

### Anything reviews should focus on/be aware of?
    Before the fix:
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/a30e21f0-9911-4965-8990-cadce4830da6" />

After the fix:

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/30cef653-bec7-46a1-845b-02f323d1bcfe" />

