### PR TITLE
DATAGO-85670: Enable the automated Backup of the IVMR configurations

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/Commander.java
+++ b/src/main/java/com/solace/tools/solconfig/Commander.java
@@ -10,6 +10,9 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.file.Files;
+import java.io.IOException;
+
 @Slf4j
 public class Commander {
     @Getter @Setter
@@ -42,6 +45,24 @@ public class Commander {
         }
         configBroker.checkAttributeCombinations(); // keep requires attribute for backup
         return configBroker;
+    }
+
+    public void dumpBackup(String resourceType, String[] objectNames, boolean isKeepDefault, String outputPath){
+        ConfigBroker backup = backup(resourceType, objectNames, isKeepDefault);
+        Path path = Path.of(outputPath);
+        printConfigBrokerToFile(backup, path);
+    }
+
+    public void printConfigBrokerToFile(ConfigBroker configBroker, Path filePath) {
+        try {
+            // Serialize the configBroker object to a string (e.g., JSON or plain text)
+            String content = configBroker.toString(); 
+            // Write the content to the specified file
+            Files.writeString(filePath, content);
+            log.info("ConfigBroker written to file: {}", filePath);
+        } catch (IOException e) {
+            log.error("Failed to write ConfigBroker to file: {}", filePath, e);
+        }
     }
 
     public void delete(String resourceType, String[] objectNames) {

--- a/src/main/java/com/solace/tools/solconfig/Commander.java
+++ b/src/main/java/com/solace/tools/solconfig/Commander.java
@@ -50,6 +50,13 @@ public class Commander {
     public void dumpBackup(String resourceType, String[] objectNames, boolean isKeepDefault, String outputPath){
         ConfigBroker backup = backup(resourceType, objectNames, isKeepDefault);
         Path path = Path.of(outputPath);
+        try {
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
+        } catch (IOException e) {
+            log.warn("Failed to create parent directories: {}", e.getMessage());
+        }
         printConfigBrokerToFile(backup, path);
     }
 

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -65,6 +65,29 @@ public class SempClient {
     private String opaquePassword;
     private final HttpClient httpClient;
 
+    public SempClient(String adminUrl, String adminUser, String adminPwd, boolean insecure, Path cacert) {
+        this.baseUrl = adminUrl + CONFIG_BASE_PATH;
+        this.adminUser = adminUser;
+        this.adminPwd = adminPwd;
+
+        var b = HttpClient.newBuilder();
+        if (insecure) {
+            Optional.ofNullable(getInscureSSLContext()).ifPresent(b::sslContext);
+        } else if (Objects.nonNull(cacert)) {
+            Optional.ofNullable(getSSLContextFrom(cacert)).ifPresent(b::sslContext);
+        }
+        this.httpClient = b
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
+                .authenticator(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(adminUser, adminPwd.toCharArray());
+                    }
+                })
+                .build();
+    }
+
     public SempClient(String adminUrl, String adminUser, String adminPwd, boolean insecure, Path cacert, String dumpPath) {
         this.baseUrl = adminUrl + CONFIG_BASE_PATH;
         this.adminUser = adminUser;

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -221,6 +221,10 @@ public class SempClient {
     }
 
     private String sendWithAbsoluteURI(String method, String absUri, String payload) {
+        return sendWithAbsoluteURI(method, absUri, payload, true);
+    }
+
+    private String sendWithAbsoluteURI(String method, String absUri, String payload, boolean retry) {
         log.info("Sending with absolute URI {} {}", method, sanitizeUri(absUri));
         var bp = Objects.isNull(payload) || payload.isEmpty() ?
                 BodyPublishers.noBody() :
@@ -229,12 +233,18 @@ public class SempClient {
                 .method(method.toUpperCase(), bp)
                 .uri(URI.create(absUri))
                 .header("content-type", "application/json")
+                .timeout(Duration.ofMinutes(3))
                 .build();
 
         HttpResponse<String> response = null;
         try {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (InterruptedException | IOException e) {
+            if (retry && e instanceof IOException) {
+                log.warn("Retrying request due to: {}", e.getMessage());
+                return sendWithAbsoluteURI(method, absUri, payload, false);
+            }
+
             Utils.errPrintlnAndExit(e, "%s %s with playload:%n%s%n%s",
                     method.toUpperCase(), sanitizeUri(absUri), sanitizeJsonBody(payload), e.toString());
         }

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -60,8 +60,6 @@ public class SempClient {
     @Getter
     private final String adminPwd;
     @Getter
-    private String dumpPath;
-    @Getter
     private String opaquePassword;
     private final HttpClient httpClient;
 
@@ -69,30 +67,6 @@ public class SempClient {
         this.baseUrl = adminUrl + CONFIG_BASE_PATH;
         this.adminUser = adminUser;
         this.adminPwd = adminPwd;
-
-        var b = HttpClient.newBuilder();
-        if (insecure) {
-            Optional.ofNullable(getInscureSSLContext()).ifPresent(b::sslContext);
-        } else if (Objects.nonNull(cacert)) {
-            Optional.ofNullable(getSSLContextFrom(cacert)).ifPresent(b::sslContext);
-        }
-        this.httpClient = b
-                .version(HttpClient.Version.HTTP_1_1)
-                .connectTimeout(Duration.ofSeconds(10))
-                .authenticator(new Authenticator() {
-                    @Override
-                    protected PasswordAuthentication getPasswordAuthentication() {
-                        return new PasswordAuthentication(adminUser, adminPwd.toCharArray());
-                    }
-                })
-                .build();
-    }
-
-    public SempClient(String adminUrl, String adminUser, String adminPwd, boolean insecure, Path cacert, String dumpPath) {
-        this.baseUrl = adminUrl + CONFIG_BASE_PATH;
-        this.adminUser = adminUser;
-        this.adminPwd = adminPwd;
-        this.dumpPath = dumpPath;
 
         var b = HttpClient.newBuilder();
         if (insecure) {

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -60,13 +60,16 @@ public class SempClient {
     @Getter
     private final String adminPwd;
     @Getter
+    private String dumpPath;
+    @Getter
     private String opaquePassword;
     private final HttpClient httpClient;
 
-    public SempClient(String adminUrl, String adminUser, String adminPwd, boolean insecure, Path cacert) {
+    public SempClient(String adminUrl, String adminUser, String adminPwd, boolean insecure, Path cacert, String dumpPath) {
         this.baseUrl = adminUrl + CONFIG_BASE_PATH;
         this.adminUser = adminUser;
         this.adminPwd = adminPwd;
+        this.dumpPath = dumpPath;
 
         var b = HttpClient.newBuilder();
         if (insecure) {

--- a/src/main/java/com/solace/tools/solconfig/cli/BackupCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/BackupCommand.java
@@ -33,7 +33,10 @@ public class BackupCommand extends SubCommand {
     protected Integer execute() {
         Commander commander = parentCommand.commander;
         commander.getSempClient().setOpaquePassword(opaquePassword);
-        commander.backup(resourceType.getFullName(), objectNames, isKeepDefault);
+        // Check if the dump path is set and not empty
+        String dumpPath = commander.getSempClient().getDumpPath();
+        if (dumpPath.isBlank()) commander.backup(resourceType.getFullName(), objectNames, isKeepDefault);
+        else commander.dumpBackup(resourceType.getFullName(), objectNames, isKeepDefault, dumpPath);
         return 0;
     }
 }

--- a/src/main/java/com/solace/tools/solconfig/cli/BackupCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/BackupCommand.java
@@ -33,10 +33,7 @@ public class BackupCommand extends SubCommand {
     protected Integer execute() {
         Commander commander = parentCommand.commander;
         commander.getSempClient().setOpaquePassword(opaquePassword);
-        // Check if the dump path is set and not empty
-        String dumpPath = commander.getSempClient().getDumpPath();
-        if (dumpPath.isBlank()) commander.backup(resourceType.getFullName(), objectNames, isKeepDefault);
-        else commander.dumpBackup(resourceType.getFullName(), objectNames, isKeepDefault, dumpPath);
+        commander.backup(resourceType.getFullName(), objectNames, isKeepDefault);
         return 0;
     }
 }

--- a/src/main/java/com/solace/tools/solconfig/cli/DumpBackupCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/DumpBackupCommand.java
@@ -17,6 +17,9 @@ public class DumpBackupCommand extends SubCommand{
     @CommandLine.Option(names = {"-O", "--opaque-password"},
             description = "The opaquePassword for receiving and updating opaque properties like the password of Client Usernames")
     private String opaquePassword;
+    @CommandLine.Option(names = "--dump-path", 
+            description = "The filepath to dump the configuration")
+    private String dumpPath= "./tmp/dump.json";
     @CommandLine.Option(names = {"-D", "--keep-default"}, description = "Whether to Keep attributes with a default value")
     private boolean isKeepDefault = false;
 
@@ -33,7 +36,7 @@ public class DumpBackupCommand extends SubCommand{
     protected Integer execute() {
         Commander commander = parentCommand.commander;
         commander.getSempClient().setOpaquePassword(opaquePassword);
-        commander.dumpBackup(resourceType.getFullName(), objectNames, isKeepDefault, commander.getSempClient().getDumpPath());
+        commander.dumpBackup(resourceType.getFullName(), objectNames, isKeepDefault, dumpPath);
         return 0;
     }
 }

--- a/src/main/java/com/solace/tools/solconfig/cli/DumpBackupCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/DumpBackupCommand.java
@@ -1,0 +1,39 @@
+package com.solace.tools.solconfig.cli;
+
+import com.solace.tools.solconfig.Commander;
+import picocli.CommandLine;
+import com.solace.tools.solconfig.model.SempSpec;
+
+import java.util.*;
+
+@CommandLine.Command(name = "dumpbackup", description = "Export the whole configuration of objects into a single JSON",
+showDefaultValues = true)
+public class DumpBackupCommand extends SubCommand{
+    @CommandLine.Parameters(index = "0",
+            description = "Type of the exported object [${COMPLETION-CANDIDATES}]")
+    private SempSpec.RES_ABBR resourceType;
+    @CommandLine.Parameters(index = "1..*", arity = "1..*", description = "One or more object names, , \"*\" means all")
+    private String[] objectNames;
+    @CommandLine.Option(names = {"-O", "--opaque-password"},
+            description = "The opaquePassword for receiving and updating opaque properties like the password of Client Usernames")
+    private String opaquePassword;
+    @CommandLine.Option(names = {"-D", "--keep-default"}, description = "Whether to Keep attributes with a default value")
+    private boolean isKeepDefault = false;
+
+
+    @Override
+    public String toString() {
+        return "DumpBackupCommand{" +
+                "resourceType=" + resourceType +
+                ", objectNames=" + Arrays.toString(objectNames) +
+                '}';
+    }
+
+    @Override
+    protected Integer execute() {
+        Commander commander = parentCommand.commander;
+        commander.getSempClient().setOpaquePassword(opaquePassword);
+        commander.dumpBackup(resourceType.getFullName(), objectNames, isKeepDefault, commander.getSempClient().getDumpPath());
+        return 0;
+    }
+}

--- a/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
                 "then use the 'create' or 'update' command to restore the configuration.",
         subcommands = {
             BackupCommand.class,
+            DumpBackupCommand.class,
             DeleteCommand.class,
             CreateCommand.class,
             UpdateCommand.class,

--- a/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
@@ -33,9 +33,6 @@ public class SempCfgCommand implements Callable<Integer> {
     @Option(names = {"-H", "--host"}, description = "URL to access the management endpoint of the broker")
     private String adminHost = "http://localhost:8080";
 
-    @Option(names = {"--dump-path"}, description = "The filepath to dump the configuration")
-    private String dumpPath = "";
-
     @Option(names = {"-u", "--admin-user"}, description = "The username of the management user")
     private String adminUser = "admin";
 
@@ -72,7 +69,7 @@ public class SempCfgCommand implements Callable<Integer> {
             adminHost = adminHost.substring(0, adminHost.length()-1);
         }
 
-        commander = Commander.ofSempClient(new SempClient(adminHost, adminUser, adminPwd, insecure, cacert, dumpPath));
+        commander = Commander.ofSempClient(new SempClient(adminHost, adminUser, adminPwd, insecure, cacert));
         commander.setCurlOnly(curlOnly);
         commander.setUseTemplate(useTemplate);
     }
@@ -83,8 +80,7 @@ public class SempCfgCommand implements Callable<Integer> {
                 "adminHost='" + adminHost + '\'' +
                 ", adminUser='" + adminUser + '\'' +
                 ", adminPwd='" + adminPwd + '\'' +
-                ", curlOnly=" + curlOnly + '\'' +
-                ", dumpPath='" + dumpPath +
+                ", curlOnly=" + curlOnly +
                 '}';
     }
 

--- a/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
+++ b/src/main/java/com/solace/tools/solconfig/cli/SempCfgCommand.java
@@ -32,6 +32,9 @@ public class SempCfgCommand implements Callable<Integer> {
     @Option(names = {"-H", "--host"}, description = "URL to access the management endpoint of the broker")
     private String adminHost = "http://localhost:8080";
 
+    @Option(names = {"--dump-path"}, description = "The filepath to dump the configuration")
+    private String dumpPath = "";
+
     @Option(names = {"-u", "--admin-user"}, description = "The username of the management user")
     private String adminUser = "admin";
 
@@ -68,7 +71,7 @@ public class SempCfgCommand implements Callable<Integer> {
             adminHost = adminHost.substring(0, adminHost.length()-1);
         }
 
-        commander = Commander.ofSempClient(new SempClient(adminHost, adminUser, adminPwd, insecure, cacert));
+        commander = Commander.ofSempClient(new SempClient(adminHost, adminUser, adminPwd, insecure, cacert, dumpPath));
         commander.setCurlOnly(curlOnly);
         commander.setUseTemplate(useTemplate);
     }
@@ -79,7 +82,8 @@ public class SempCfgCommand implements Callable<Integer> {
                 "adminHost='" + adminHost + '\'' +
                 ", adminUser='" + adminUser + '\'' +
                 ", adminPwd='" + adminPwd + '\'' +
-                ", curlOnly=" + curlOnly +
+                ", curlOnly=" + curlOnly + '\'' +
+                ", dumpPath='" + dumpPath +
                 '}';
     }
 


### PR DESCRIPTION
### What is the purpose of this change?
- Add a command which will dump the configurations into a json file in a specified directory. 
    - This was not being done when running the `backup` command. 

### How is this accomplished?
- Added new functions in `Commander.java` which when called, do the backup, and then store the result into a json file. 
- There are some verification steps to ensure the file path specified by the command exists. If it does not, it will be created. 
- Error handling has also been added when writing to the json file.
- The command follows the same structure as other commands

`Tested with vpn only`

### Anything reviews should focus on/be aware of?


<!--start_gitstream_placeholder-->
### ✨ PR Description
### What is the purpose of this change?
Add functionality to automate the backup of IVMR configurations to files, improving system reliability and disaster recovery capabilities.

### How is this accomplished?
- Added new `dumpBackup()` method in `Commander.java` to generate and save configurations to specified file paths
- Created `printConfigBrokerToFile()` method to handle the serialization and file writing operations
- Added timeout and retry mechanism to `SempClient.java` to improve reliability of API calls
- Implemented new `DumpBackupCommand` class that exposes the backup functionality through CLI with options for path specification and attribute control
- Registered the new command in `SempCfgCommand.java` to make it accessible in the command line interface

### Anything reviews should focus on/be aware of?
- The `printConfigBrokerToFile()` method uses `toString()` for serialization, which may not be ideal for complex objects - consider using a dedicated JSON serializer
- File operation error handling could be improved - currently only logs errors without propagating them
- The default dump path (`./tmp/dump.json`) might need review for cross-platform compatibility
- The 3-minute timeout on HTTP requests is significantly long and might need adjustment for production environments

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
