### PR TITLE
DATAGO-106068: add retry and timeout

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -221,6 +221,10 @@ public class SempClient {
     }
 
     private String sendWithAbsoluteURI(String method, String absUri, String payload) {
+        return sendWithAbsoluteURI(method, absUri, payload, true);
+    }
+
+    private String sendWithAbsoluteURI(String method, String absUri, String payload, boolean retry) {
         log.info("Sending with absolute URI {} {}", method, sanitizeUri(absUri));
         var bp = Objects.isNull(payload) || payload.isEmpty() ?
                 BodyPublishers.noBody() :
@@ -229,12 +233,18 @@ public class SempClient {
                 .method(method.toUpperCase(), bp)
                 .uri(URI.create(absUri))
                 .header("content-type", "application/json")
+                .timeout(Duration.ofMinutes(3))
                 .build();
 
         HttpResponse<String> response = null;
         try {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (InterruptedException | IOException e) {
+            if (retry && e instanceof IOException) {
+                log.warn("Retrying request due to: {}", e.getMessage());
+                return sendWithAbsoluteURI(method, absUri, payload, false);
+            }
+
             Utils.errPrintlnAndExit(e, "%s %s with playload:%n%s%n%s",
                     method.toUpperCase(), sanitizeUri(absUri), sanitizeJsonBody(payload), e.toString());
         }


### PR DESCRIPTION
### What is the purpose of this change?

Add a retry mechanism to requests and set the timeout to 3 minutes.

We were receiving intermittent connection failures when connecting to the AU production IVMR, probably due to the distance. The connection failures were taking 30 minutes to fail. From the log output a normal request was about 0.3 seconds.

### How is this accomplished?


### Anything reviews should focus on/be aware of?


<!--start_gitstream_placeholder-->
### ✨ PR Description
### What is the purpose of this change?
Add retry mechanism and request timeout to SempClient HTTP requests to improve reliability when communicating with SEMP API

### How is this accomplished?
- Added an overloaded `sendWithAbsoluteURI` method with a retry parameter
- Implemented a single retry attempt when encountering IOException during HTTP requests
- Added a 3-minute timeout configuration to all HTTP requests to prevent indefinite waiting

### Anything reviews should focus on/be aware of?
- The retry mechanism is limited to IOException and only attempts once
- The 3-minute timeout may need adjustment based on production performance
- Consider if other exception types should also trigger retries

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
