### PR TITLE
DATAGO-109780: add pagination settings to bypass broker bug with MQTT sessions, could be roll-backed after the issue is resolved

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,13 @@ jar {
 
 dependencies {
     // Use JUnit Jupiter for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
 
     // Use JUnit Jupiter Engine for testing.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
 
     // This dependency is used by the application.
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
@@ -50,12 +53,14 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.5.18'
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
     implementation 'org.freemarker:freemarker:2.3.31'
-    implementation("net.logstash.logback:logstash-logback-encoder:6.6")
+    implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 }
 
 tasks.named('test') {
     // Use junit platform for unit tests.
-    useJUnitPlatform()
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter'
+    }
 }
 
 publishing {

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,6 +53,8 @@ import java.util.stream.Collectors;
 public class SempClient {
     private static final String CONFIG_BASE_PATH = "/SEMP/v2/config";
     public static final int HTTP_OK = 200;
+    private static final String DEFAULT_PAGINATION_COUNT = "10";
+    private final String paginationCount;
 
     @Getter
     private final String baseUrl;
@@ -67,6 +70,9 @@ public class SempClient {
         this.baseUrl = adminUrl + CONFIG_BASE_PATH;
         this.adminUser = adminUser;
         this.adminPwd = adminPwd;
+        
+        Properties properties = PropertiesLoader.loadProperties("application.properties");
+        this.paginationCount = properties.getProperty("solace.tools.solconfig.pagination.count", DEFAULT_PAGINATION_COUNT);
 
         var b = HttpClient.newBuilder();
         if (insecure) {
@@ -174,6 +180,11 @@ public class SempClient {
         var q = (uri.contains("?") ? "&" : "?") + SempSpec.OPAQUE_PASSWORD + "=" + opaquePassword;
         return uri + q;
     }
+    
+    private String uriAddPaginationCount(String uri) {
+        var q = (uri.contains("?") ? "&" : "?") + "count=" + paginationCount;
+        return uri + q;
+    }
 
     public String getBrokerSpec() {
         return sendWithResourcePath(HTTPMethod.GET.name(), "/spec", null);
@@ -188,7 +199,8 @@ public class SempClient {
      */
     public SempResponse getCollectionWithAbsoluteUri(String absUri) {
         List<SempResponse> responseList = new LinkedList<>();
-        Optional<String> nextPageUri = Optional.of(absUri);
+        String initialUri = uriAddPaginationCount(absUri);
+        Optional<String> nextPageUri = Optional.of(initialUri);
         while (nextPageUri.isPresent()) {
             SempResponse resp = SempResponse.ofString(sendWithAbsoluteURI("GET", uriAddOpaquePassword(nextPageUri.get()), null));
             responseList.add(resp);

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -45,16 +45,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.solace.tools.solconfig.Utils.properties;
 
 @Slf4j
 public class SempClient {
     private static final String CONFIG_BASE_PATH = "/SEMP/v2/config";
     public static final int HTTP_OK = 200;
-    private static final String DEFAULT_PAGINATION_COUNT = "10";
-    private final String paginationCount;
+    
+    private final String paginationCount = properties.getProperty("solace.tools.solconfig.pagination.count", "10");
 
     @Getter
     private final String baseUrl;
@@ -70,9 +71,6 @@ public class SempClient {
         this.baseUrl = adminUrl + CONFIG_BASE_PATH;
         this.adminUser = adminUser;
         this.adminPwd = adminPwd;
-        
-        Properties properties = PropertiesLoader.loadProperties("application.properties");
-        this.paginationCount = properties.getProperty("solace.tools.solconfig.pagination.count", DEFAULT_PAGINATION_COUNT);
 
         var b = HttpClient.newBuilder();
         if (insecure) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ solace.tools.solconfig.objects.reserved.excludeList = /msgVpns/queues,/msgVpns/q
 
 # Exceptions to the reserved objects id list
 solace.tools.solconfig.objects.reserved.excludeObjectIdList =
+
+# Pagination configuration
+solace.tools.solconfig.pagination.count = 30


### PR DESCRIPTION
### What is the purpose of this change?
    error when trying to fetch more than 10 mqtt sessions

### How is this accomplished?
    added workaround for 30 sessions to be fetched 

### Anything reviews should focus on/be aware of?
    ...

<!--start_gitstream_placeholder-->
### ✨ PR Description
### What is the purpose of this change?
Add pagination settings to SempClient to work around a broker bug with MQTT sessions

### How is this accomplished?
- Add a configurable pagination count property with a default value of 10
- Update getCollectionWithAbsoluteUri to apply pagination count to API requests
- Set pagination count to 30 in application.properties
- Add utility method uriAddPaginationCount to append pagination parameters to requests

### Anything reviews should focus on/be aware of?
- This is a temporary workaround that should be rolled back after the MQTT sessions broker bug is resolved
- The pagination count of 30 may need adjustment based on performance testing
- Ensure the pagination implementation doesn't break existing collection retrieval functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
