### PR TITLE
DATAGO-125904: Update logback-classic dependency to version 1.5.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
     implementation 'info.picocli:picocli:4.7.0'
     annotationProcessor 'info.picocli:picocli-codegen:4.7.0'
-    implementation 'ch.qos.logback:logback-classic:1.5.18'
+    implementation 'ch.qos.logback:logback-classic:1.5.19'
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
     implementation 'org.freemarker:freemarker:2.3.31'
     implementation("net.logstash.logback:logstash-logback-encoder:8.0")

--- a/build.gradle
+++ b/build.gradle
@@ -84,4 +84,3 @@ publishing {
     }
 }
 
-

--- a/build.gradle
+++ b/build.gradle
@@ -84,3 +84,4 @@ publishing {
     }
 }
 
+


### PR DESCRIPTION
### What is the purpose of this change?
    Vulnerability fix for https://nvd.nist.gov/vuln/detail/CVE-2025-11226

### How is this accomplished?
    Update logback-classic dependency to version 1.5.19

### Anything reviews should focus on/be aware of?
    ...
