### PR TITLE
DATAGO-134591: update to support dev broker semp versions

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/model/SempVersion.java
+++ b/src/main/java/com/solace/tools/solconfig/model/SempVersion.java
@@ -18,14 +18,30 @@ public class SempVersion implements Comparable<SempVersion>{
         String[] v = version.split("\\.");
 
         // both "2.22" and "2.11.00091010036" are legal version, check https://github.com/flyisland/solconfig/issues/3
+        // Dev-build brokers report a version like "100.0SOL-143449.0.7010" — the minor segment
+        // carries a branch/ticket suffix.  Use parseLeadingInt so we accept those strings and
+        // treat them as their leading numeric value (e.g. "0SOL-143449" → 0).
         if (v.length < 2) {
             Utils.errPrintlnAndExit(new IllegalArgumentException(version+" is an illegal SEMPv2 version."),"Unable to new a SempVersion object");
         }
         try {
-            number = Integer.parseInt(v[0]) * 1000 + Integer.parseInt(v[1]);
+            number = parseLeadingInt(v[0]) * 1000 + parseLeadingInt(v[1]);
         }catch (NumberFormatException e){
             Utils.errPrintlnAndExit(new IllegalArgumentException(version+" is an illegal SEMPv2 version."),"Unable to new a SempVersion object");
         }
+    }
+
+    // Parses the leading numeric prefix of a version segment, stopping at the first
+    // non-digit character.  Mirrors EventBrokerVersionUtil.parseLeadingInt in maas-base.
+    private static int parseLeadingInt(String segment) {
+        int i = 0;
+        while (i < segment.length() && Character.isDigit(segment.charAt(i))) {
+            i++;
+        }
+        if (i == 0) {
+            throw new NumberFormatException("For input string: \"" + segment + "\"");
+        }
+        return Integer.parseInt(segment.substring(0, i));
     }
 
     @Override

--- a/src/main/java/com/solace/tools/solconfig/model/SempVersion.java
+++ b/src/main/java/com/solace/tools/solconfig/model/SempVersion.java
@@ -18,13 +18,11 @@ public class SempVersion implements Comparable<SempVersion>{
         String[] v = version.split("\\.");
 
         // both "2.22" and "2.11.00091010036" are legal version, check https://github.com/flyisland/solconfig/issues/3
-        // Dev-build brokers report a version like "100.0SOL-143449.0.7010" — the minor segment
-        // carries a branch/ticket suffix.  Use parseLeadingInt so we accept those strings and
-        // treat them as their leading numeric value (e.g. "0SOL-143449" → 0).
         if (v.length < 2) {
             Utils.errPrintlnAndExit(new IllegalArgumentException(version+" is an illegal SEMPv2 version."),"Unable to new a SempVersion object");
         }
         try {
+            // dev-build minor segments like "0SOL-143449" or "0main" parse to their leading int (0)
             number = parseLeadingInt(v[0]) * 1000 + parseLeadingInt(v[1]);
         }catch (NumberFormatException e){
             Utils.errPrintlnAndExit(new IllegalArgumentException(version+" is an illegal SEMPv2 version."),"Unable to new a SempVersion object");

--- a/src/test/java/com/solace/tools/solconfig/model/SempVersionTest.java
+++ b/src/test/java/com/solace/tools/solconfig/model/SempVersionTest.java
@@ -66,6 +66,33 @@ class SempVersionTest {
         assertEquals(expectedSign, Integer.signum(result));
     }
 
+    // Dev-build brokers report minor segments like "0SOL-143449" or "0main"; these should
+    // parse without throwing and compute the same number as the plain numeric equivalent.
+    @ParameterizedTest
+    @CsvSource({
+            "100.0main.0.7706, 100.0",
+            "100.0SOL-143449.0.7010, 100.0"
+    })
+    void devBuildMinorSegment_parsesAsLeadingInt(String devVersion, String equivalentVersion) {
+        assertDoesNotThrow(() -> new SempVersion(devVersion));
+        // number = major*1000 + leadingInt(minor); "0main"/"0SOL-..." both lead with 0
+        assertEquals(0, new SempVersion(devVersion).compareTo(new SempVersion(equivalentVersion)));
+    }
+
+    // Regression: standard versions with a numeric minor must still compute correctly.
+    @Test
+    void regression_standardVersion_9_6_producesCorrectNumber() {
+        SempVersion v = new SempVersion("9.6.0.34");
+        assertEquals(9006, getNumber(v));
+    }
+
+    // A segment with no leading digits (e.g. "main.0") has no numeric prefix to parse,
+    // so errPrintlnAndExit is called (throws SolConfigException in non-exit test mode).
+    @Test
+    void noLeadingDigits_callsErrPrintlnAndExit() {
+        assertThrows(SolConfigException.class, () -> new SempVersion("main.0"));
+    }
+
     private int getNumber(SempVersion sempVersion) {
         String text = sempVersion.getText();
         String[] parts = text.split("\\.");


### PR DESCRIPTION
### What is the purpose of this change?

DATAGO-134591: Dev-build event brokers report a SEMP version string where the minor segment carries a branch or ticket suffix, for example `100.0SOL-143449.0.7010` or `100.0main.0.7706`. The existing `SempVersion` constructor called `Integer.parseInt` on every dot-separated segment, which throws `NumberFormatException` on those strings and causes the broker config download to fail.

### How is this accomplished?

A private `parseLeadingInt(String segment)` helper is added to `SempVersion`. It reads the leading numeric digits of a segment and stops at the first non-digit character, mirroring `EventBrokerVersionUtil.parseLeadingInt` in `maas-base`. The constructor now calls `parseLeadingInt` instead of `Integer.parseInt` for both the major and minor segments, so `"0SOL-143449"` is treated as `0` and `"100"` stays `100`.

The helper still throws `NumberFormatException` (re-wrapped by the existing catch block) if the segment has **no** leading digits, preserving the current error behaviour for truly malformed version strings.

### Anything reviewers should focus on/be aware of?

- `parseLeadingInt` is intentionally private — it is a local copy of the logic in `maas-base` rather than a shared dependency, because this repo does not depend on `maas-base`.
- The change is confined to parsing; the `number` field computation (`major * 1000 + minor`) and all comparison / equality semantics are unchanged.
- Dev-build minor segments like `"0SOL-143449"` and `"0main"` both parse to `0`, which is the correct minor value for those branches.