### PR TITLE
DATAGO-131819: fix NPE in SempClient.getCollectionWithAbsoluteUri

### DIFF
--- a/src/main/java/com/solace/tools/solconfig/Commander.java
+++ b/src/main/java/com/solace/tools/solconfig/Commander.java
@@ -94,7 +94,7 @@ public class Commander {
                 List<Map<String, Object>> data = sempResponse.getData();
                 List<Map<String, String>> links = sempResponse.getLinks();
                 for (int i = 0; i < data.size(); i++) {
-                    var child = configObject.addChild(collectionName, data.get(i));
+                    ConfigObject child = configObject.addChild(collectionName, data.get(i));
                     getChildrenRecursively(child, links.get(i));
                 }
             });

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -205,10 +205,17 @@ public class SempClient {
             nextPageUri = resp.getNextPageUri();
         }
         // Combine all paging results into one SempResponse
-        var result = responseList.stream().reduce((r1, r2) -> {
-            r1.getData().addAll(r2.getData());
-            r1.getLinks().addAll(r2.getLinks());
-            r1.setMeta(r2.getMeta());
+        Optional<SempResponse> result = responseList.stream().reduce((r1, r2) -> {
+            Optional<List<Map<String, Object>>> dataOpt = Optional.ofNullable(r2.getData());
+            Optional<List<Map<String, String>>> dataLinks = Optional.ofNullable(r2.getLinks());
+            if (dataOpt.isPresent() && dataLinks.isPresent()) {
+                // need to be together because they form a page
+                r1.getData().addAll(dataOpt.get());
+                r1.getLinks().addAll(dataLinks.get());
+            }
+            // I don't think this is ever read. Kept for backwards compatibility
+            Optional.ofNullable(r2.getMeta())
+                    .ifPresent(r1::setMeta);
             return r1;
         });
         return result.orElse(null);

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -206,6 +206,12 @@ public class SempClient {
         }
         // Combine all paging results into one SempResponse
         Optional<SempResponse> result = responseList.stream().reduce((r1, r2) -> {
+            if(r1.getLinks() == null){
+                r1.setLinks(new LinkedList<>());
+            }
+            if(r1.getData() == null){
+                r1.setData(new LinkedList<>());
+            }
             Optional<List<Map<String, Object>>> dataOpt = Optional.ofNullable(r2.getData());
             Optional<List<Map<String, String>>> dataLinks = Optional.ofNullable(r2.getLinks());
             if (dataOpt.isPresent() && dataLinks.isPresent()) {

--- a/src/main/java/com/solace/tools/solconfig/SempClient.java
+++ b/src/main/java/com/solace/tools/solconfig/SempClient.java
@@ -205,26 +205,22 @@ public class SempClient {
             nextPageUri = resp.getNextPageUri();
         }
         // Combine all paging results into one SempResponse
-        Optional<SempResponse> result = responseList.stream().reduce((r1, r2) -> {
-            if(r1.getLinks() == null){
-                r1.setLinks(new LinkedList<>());
-            }
-            if(r1.getData() == null){
-                r1.setData(new LinkedList<>());
-            }
-            Optional<List<Map<String, Object>>> dataOpt = Optional.ofNullable(r2.getData());
-            Optional<List<Map<String, String>>> dataLinks = Optional.ofNullable(r2.getLinks());
-            if (dataOpt.isPresent() && dataLinks.isPresent()) {
-                // need to be together because they form a page
-                r1.getData().addAll(dataOpt.get());
-                r1.getLinks().addAll(dataLinks.get());
-            }
-            // I don't think this is ever read. Kept for backwards compatibility
-            Optional.ofNullable(r2.getMeta())
-                    .ifPresent(r1::setMeta);
-            return r1;
-        });
+        Optional<SempResponse> result = responseList.stream().reduce(SempClient::mergeResponses);
         return result.orElse(null);
+    }
+
+    /**
+     * Merge {@code page} into {@code acc} by appending data and links and overwriting
+     * meta when present. {@link SempResponse} guarantees non-null {@code data} and
+     * {@code links}, so no null checks are needed here.
+     *
+     * @return the mutated accumulator {@code acc}
+     */
+    static SempResponse mergeResponses(SempResponse acc, SempResponse page) {
+        acc.getData().addAll(page.getData());
+        acc.getLinks().addAll(page.getLinks());
+        Optional.ofNullable(page.getMeta()).ifPresent(acc::setMeta);
+        return acc;
     }
 
     public String buildAbsoluteUri(String resourcePath) {

--- a/src/main/java/com/solace/tools/solconfig/model/SempResponse.java
+++ b/src/main/java/com/solace/tools/solconfig/model/SempResponse.java
@@ -8,7 +8,6 @@ import com.solace.tools.solconfig.Utils;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.solace.tools.solconfig.Utils.objectMapper;
@@ -38,13 +37,10 @@ public class SempResponse {
     }
 
     public Optional<String> getNextPageUri(){
-        return Optional.of(meta).map(SempMeta::getPaging).map(SempMeta.SempPaging::getNextPageUri);
+        return Optional.ofNullable(meta).map(SempMeta::getPaging).map(SempMeta.SempPaging::getNextPageUri);
     }
 
     public boolean isEmpty(){
-        if (Objects.isNull(data)){
-            return true;
-        }
         return data.isEmpty();
     }
 

--- a/src/main/java/com/solace/tools/solconfig/model/SempResponse.java
+++ b/src/main/java/com/solace/tools/solconfig/model/SempResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import com.solace.tools.solconfig.Utils;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -15,16 +16,18 @@ import static com.solace.tools.solconfig.Utils.objectMapper;
 @Getter
 @Setter
 public class SempResponse {
-    private List<Map<String, Object>> data;
-    private List<Map<String, String >> links;
+    private List<Map<String, Object>> data = new LinkedList<>();
+    private List<Map<String, String >> links = new LinkedList<>();
     private SempMeta meta;
 
     public static SempResponse ofString(String content){
         SempResponse resp = new SempResponse();
         try {
             var node = objectMapper.readTree(content);
-            resp.data = objectMapper.treeToValue(node.get("data"), List.class);
-            resp.links = objectMapper.treeToValue(node.get("links"), List.class);
+            List<Map<String, Object>> parsedData = objectMapper.treeToValue(node.get("data"), List.class);
+            List<Map<String, String>> parsedLinks = objectMapper.treeToValue(node.get("links"), List.class);
+            resp.data = parsedData != null ? parsedData : new LinkedList<>();
+            resp.links = parsedLinks != null ? parsedLinks : new LinkedList<>();
             resp.meta = SempMeta.ofJsonNode(node.get("meta"));
         } catch (JsonProcessingException e) {
             Utils.errPrintlnAndExit(e,

--- a/src/test/java/com/solace/tools/solconfig/SempClientTest.java
+++ b/src/test/java/com/solace/tools/solconfig/SempClientTest.java
@@ -1,0 +1,110 @@
+package com.solace.tools.solconfig;
+
+import com.solace.tools.solconfig.model.SempMeta;
+import com.solace.tools.solconfig.model.SempResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SempClientTest {
+
+    @Test
+    void mergeResponses_bothPopulated_concatenatesDataAndLinks() {
+        SempResponse acc = responseWith(List.of(Map.of("q", "q1")), List.of(Map.of("uri", "u1")));
+        SempResponse page = responseWith(List.of(Map.of("q", "q2")), List.of(Map.of("uri", "u2")));
+
+        SempResponse result = SempClient.mergeResponses(acc, page);
+
+        assertSame(acc, result);
+        assertEquals(2, result.getData().size());
+        assertEquals(2, result.getLinks().size());
+        assertEquals("q1", result.getData().get(0).get("q"));
+        assertEquals("q2", result.getData().get(1).get("q"));
+    }
+
+    @Test
+    void mergeResponses_pageHasEmptyDataAndLinks_returnsAccUnchanged() {
+        SempResponse acc = responseWith(List.of(Map.of("q", "q1")), List.of(Map.of("uri", "u1")));
+        SempResponse page = new SempResponse();
+
+        SempResponse result = SempClient.mergeResponses(acc, page);
+
+        assertSame(acc, result);
+        assertEquals(1, result.getData().size());
+        assertEquals(1, result.getLinks().size());
+    }
+
+    @Test
+    void mergeResponses_accHasEmptyDataAndLinks_takesFromPage() {
+        SempResponse acc = new SempResponse();
+        SempResponse page = responseWith(List.of(Map.of("q", "q1")), List.of(Map.of("uri", "u1")));
+
+        SempResponse result = SempClient.mergeResponses(acc, page);
+
+        assertSame(acc, result);
+        assertEquals(1, result.getData().size());
+        assertEquals(1, result.getLinks().size());
+    }
+
+    @Test
+    void mergeResponses_pageHasMeta_overwritesAccMeta() {
+        SempResponse acc = new SempResponse();
+        SempMeta accMeta = new SempMeta();
+        accMeta.setResponseCode(200);
+        acc.setMeta(accMeta);
+
+        SempResponse page = new SempResponse();
+        SempMeta pageMeta = new SempMeta();
+        pageMeta.setResponseCode(204);
+        page.setMeta(pageMeta);
+
+        SempClient.mergeResponses(acc, page);
+
+        assertNotNull(acc.getMeta());
+        assertEquals(204, acc.getMeta().getResponseCode());
+    }
+
+    @Test
+    void mergeResponses_pageNullMeta_preservesAccMeta() {
+        SempResponse acc = new SempResponse();
+        SempMeta accMeta = new SempMeta();
+        accMeta.setResponseCode(200);
+        acc.setMeta(accMeta);
+
+        SempResponse page = new SempResponse();
+
+        SempClient.mergeResponses(acc, page);
+
+        assertNotNull(acc.getMeta());
+        assertEquals(200, acc.getMeta().getResponseCode());
+    }
+
+    @Test
+    void mergeResponses_reproducesProductionNpeScenario_doesNotThrow() {
+        // Production case: a paginated response page came back with empty/null data and links.
+        // Pre-fix this triggered NPE inside addAll. After fix, SempResponse guarantees
+        // non-null collections, so merge is safe.
+        SempResponse acc = new SempResponse();
+        SempResponse emptyPage = new SempResponse();
+
+        SempResponse result = SempClient.mergeResponses(acc, emptyPage);
+
+        assertTrue(result.getData().isEmpty());
+        assertTrue(result.getLinks().isEmpty());
+    }
+
+    private static SempResponse responseWith(List<Map<String, Object>> data,
+                                             List<Map<String, String>> links) {
+        SempResponse r = new SempResponse();
+        r.setData(new LinkedList<>(data));
+        r.setLinks(new LinkedList<>(links));
+        return r;
+    }
+}

--- a/src/test/java/com/solace/tools/solconfig/model/SempResponseTest.java
+++ b/src/test/java/com/solace/tools/solconfig/model/SempResponseTest.java
@@ -1,0 +1,132 @@
+package com.solace.tools.solconfig.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SempResponseTest {
+
+    private static final String FULL_RESPONSE = "{" +
+            "\"data\":[{\"queueName\":\"q1\"},{\"queueName\":\"q2\"}]," +
+            "\"links\":[{\"uri\":\"u1\"},{\"uri\":\"u2\"}]," +
+            "\"meta\":{\"responseCode\":200,\"request\":{\"method\":\"GET\",\"uri\":\"/x\"}}" +
+            "}";
+
+    private static final String NULL_DATA_RESPONSE = "{" +
+            "\"data\":null," +
+            "\"links\":[{\"uri\":\"u1\"}]," +
+            "\"meta\":{\"responseCode\":200,\"request\":{\"method\":\"GET\",\"uri\":\"/x\"}}" +
+            "}";
+
+    private static final String NULL_LINKS_RESPONSE = "{" +
+            "\"data\":[{\"queueName\":\"q1\"}]," +
+            "\"links\":null," +
+            "\"meta\":{\"responseCode\":200,\"request\":{\"method\":\"GET\",\"uri\":\"/x\"}}" +
+            "}";
+
+    private static final String BOTH_NULL_RESPONSE = "{" +
+            "\"data\":null," +
+            "\"links\":null," +
+            "\"meta\":{\"responseCode\":200,\"request\":{\"method\":\"GET\",\"uri\":\"/x\"}}" +
+            "}";
+
+    private static final String MISSING_FIELDS_RESPONSE = "{" +
+            "\"meta\":{\"responseCode\":200,\"request\":{\"method\":\"GET\",\"uri\":\"/x\"}}" +
+            "}";
+
+    private static final String NO_META_RESPONSE = "{" +
+            "\"data\":[{\"queueName\":\"q1\"}]," +
+            "\"links\":[{\"uri\":\"u1\"}]" +
+            "}";
+
+    @Test
+    void defaultConstructor_dataAndLinksAreEmptyNotNull() {
+        SempResponse resp = new SempResponse();
+
+        assertNotNull(resp.getData());
+        assertNotNull(resp.getLinks());
+        assertTrue(resp.getData().isEmpty());
+        assertTrue(resp.getLinks().isEmpty());
+    }
+
+    @Test
+    void ofString_validResponse_populatesAllFields() {
+        SempResponse resp = SempResponse.ofString(FULL_RESPONSE);
+
+        assertEquals(2, resp.getData().size());
+        assertEquals(2, resp.getLinks().size());
+        assertNotNull(resp.getMeta());
+        assertEquals(200, resp.getMeta().getResponseCode());
+    }
+
+    @Test
+    void ofString_nullDataField_returnsEmptyList() {
+        SempResponse resp = SempResponse.ofString(NULL_DATA_RESPONSE);
+
+        assertNotNull(resp.getData());
+        assertTrue(resp.getData().isEmpty());
+        assertEquals(1, resp.getLinks().size());
+    }
+
+    @Test
+    void ofString_nullLinksField_returnsEmptyList() {
+        SempResponse resp = SempResponse.ofString(NULL_LINKS_RESPONSE);
+
+        assertNotNull(resp.getLinks());
+        assertTrue(resp.getLinks().isEmpty());
+        assertEquals(1, resp.getData().size());
+    }
+
+    @Test
+    void ofString_bothDataAndLinksNull_returnsEmptyLists() {
+        SempResponse resp = SempResponse.ofString(BOTH_NULL_RESPONSE);
+
+        assertNotNull(resp.getData());
+        assertNotNull(resp.getLinks());
+        assertTrue(resp.getData().isEmpty());
+        assertTrue(resp.getLinks().isEmpty());
+    }
+
+    @Test
+    void ofString_missingDataAndLinksKeys_returnsEmptyLists() {
+        SempResponse resp = SempResponse.ofString(MISSING_FIELDS_RESPONSE);
+
+        assertNotNull(resp.getData());
+        assertNotNull(resp.getLinks());
+        assertTrue(resp.getData().isEmpty());
+        assertTrue(resp.getLinks().isEmpty());
+    }
+
+    @Test
+    void ofString_missingMeta_metaIsNull() {
+        SempResponse resp = SempResponse.ofString(NO_META_RESPONSE);
+
+        assertNull(resp.getMeta());
+        assertEquals(1, resp.getData().size());
+    }
+
+    @Test
+    void isEmpty_afterOfStringWithNullData_returnsTrue() {
+        SempResponse resp = SempResponse.ofString(NULL_DATA_RESPONSE);
+
+        assertTrue(resp.isEmpty());
+    }
+
+    @Test
+    void isEmpty_afterOfStringWithDataPresent_returnsFalse() {
+        SempResponse resp = SempResponse.ofString(FULL_RESPONSE);
+
+        assertFalse(resp.isEmpty());
+    }
+
+    @Test
+    void isEmpty_afterDefaultConstructor_returnsTrue() {
+        SempResponse resp = new SempResponse();
+
+        assertTrue(resp.isEmpty());
+    }
+}

--- a/src/test/java/com/solace/tools/solconfig/model/SempResponseTest.java
+++ b/src/test/java/com/solace/tools/solconfig/model/SempResponseTest.java
@@ -129,4 +129,32 @@ class SempResponseTest {
 
         assertTrue(resp.isEmpty());
     }
+
+    @Test
+    void getNextPageUri_metaIsNull_returnsEmptyOptional() {
+        SempResponse resp = SempResponse.ofString(NO_META_RESPONSE);
+
+        assertTrue(resp.getNextPageUri().isEmpty());
+    }
+
+    @Test
+    void getNextPageUri_metaPresentButPagingMissing_returnsEmptyOptional() {
+        SempResponse resp = SempResponse.ofString(FULL_RESPONSE);
+
+        assertTrue(resp.getNextPageUri().isEmpty());
+    }
+
+    @Test
+    void getNextPageUri_pagingPresent_returnsNextPageUri() {
+        String paginated = "{" +
+                "\"data\":[]," +
+                "\"links\":[]," +
+                "\"meta\":{\"responseCode\":200,\"paging\":{\"nextPageUri\":\"https://broker/SEMP/v2/config/page2\"}}" +
+                "}";
+
+        SempResponse resp = SempResponse.ofString(paginated);
+
+        assertTrue(resp.getNextPageUri().isPresent());
+        assertEquals("https://broker/SEMP/v2/config/page2", resp.getNextPageUri().get());
+    }
 }


### PR DESCRIPTION
### What is the purpose of this change?

Fixes a NullPointerException in `SempClient.getCollectionWithAbsoluteUri` (DATAGO-131819) observed in production cloud-agent logs. The NPE was thrown when a paginated SEMP response contained null `data` or `links`, and the `reduce(...)` lambda called `addAll(null)`. It propagated as an `ActionSupportException` from `BrokerConfigsManagerImpl.fetchBrokerConfigs`, preventing customers from reading or backing up broker configs.

Original stack trace excerpt:
```
java.lang.NullPointerException: Cannot invoke "java.util.Collection.toArray()" because "<parameter1>" is null
  at java.util.ArrayList.addAll(...)
  at com.solace.tools.solconfig.SempClient.lambda$getCollectionWithAbsoluteUri$0(SempClient.java:209)
```

### How is this accomplished?

Root cause: `SempResponse.ofString` assigned `null` to `data` and `links` whenever the underlying JSON node was null or missing. Multiple downstream sites then had to remember to null-check.

Fix at the source: `SempResponse` now guarantees non-null `data` and `links`:
- Field defaults are `new LinkedList<>()`.
- `ofString` coerces any null parse result to an empty `LinkedList`.

The reduce lambda in `SempClient.getCollectionWithAbsoluteUri` is extracted to a package-private static `mergeResponses(acc, page)` so it can be unit-tested without standing up the HTTP client. With the source-level invariant, the merge becomes a straightforward concatenation plus the existing meta-overwrite.

Adds **16 new unit tests** across:
- `SempResponseTest` — null/missing `data`/`links`/`meta`, default constructor invariants, `isEmpty()` semantics.
- `SempClientTest` — happy-path merge, empty-page merge, meta overwrite/preserve, and a regression test reproducing the production NPE scenario.

### Anything reviews should focus on/be aware of?

- The two earlier commits on this branch (`2f24453`, `c639eb9`) were exploratory band-aids in the lambda; this commit supersedes them with a root-cause fix while keeping their intent (null-tolerance). Net result is simpler than either alone.
- `SempResponse` field defaults changed from implicit-null to empty list. The only behavior change for callers is that `getData() == null` and `getLinks() == null` will no longer be observed. All existing callers either go through `isEmpty()` (which handles either case) or iterate the list (which now safely iterates an empty list).
- Once this PR merges, a `0.0.20` release of `maas-pubsubplus-configs` should be cut and `maas-cloud-agent-lib` bumped to consume it (currently pinned at `0.0.19`).